### PR TITLE
Create .NET catalog service skeleton

### DIFF
--- a/FastTechFoods.sln
+++ b/FastTechFoods.sln
@@ -1,0 +1,48 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{5A0D4392-0E94-48F3-889D-8A344F2A074F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Domain", "src\FastTechFoods.Domain\FastTechFoods.Domain.csproj", "{35143948-E620-4558-B567-1F375A013EEC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Application", "src\FastTechFoods.Application\FastTechFoods.Application.csproj", "{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Infrastructure", "src\FastTechFoods.Infrastructure\FastTechFoods.Infrastructure.csproj", "{CF68CDE7-3D6E-4420-A349-EC344099A159}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Api", "src\FastTechFoods.Api\FastTechFoods.Api.csproj", "{927CD36E-984D-4A4E-87EA-B77BF07BB54A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{35143948-E620-4558-B567-1F375A013EEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35143948-E620-4558-B567-1F375A013EEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35143948-E620-4558-B567-1F375A013EEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35143948-E620-4558-B567-1F375A013EEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CF68CDE7-3D6E-4420-A349-EC344099A159}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CF68CDE7-3D6E-4420-A349-EC344099A159}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CF68CDE7-3D6E-4420-A349-EC344099A159}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CF68CDE7-3D6E-4420-A349-EC344099A159}.Release|Any CPU.Build.0 = Release|Any CPU
+		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{35143948-E620-4558-B567-1F375A013EEC} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+		{CF68CDE7-3D6E-4420-A349-EC344099A159} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+		{927CD36E-984D-4A4E-87EA-B77BF07BB54A} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+	EndGlobalSection
+EndGlobal

--- a/src/FastTechFoods.Api/FastTechFoods.Api.csproj
+++ b/src/FastTechFoods.Api/FastTechFoods.Api.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.17" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastTechFoods.Application\FastTechFoods.Application.csproj" />
+    <ProjectReference Include="..\FastTechFoods.Infrastructure\FastTechFoods.Infrastructure.csproj" />
+    <ProjectReference Include="..\FastTechFoods.Domain\FastTechFoods.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/FastTechFoods.Api/FastTechFoods.Api.http
+++ b/src/FastTechFoods.Api/FastTechFoods.Api.http
@@ -1,0 +1,6 @@
+@FastTechFoods.Api_HostAddress = http://localhost:5038
+
+GET {{FastTechFoods.Api_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/src/FastTechFoods.Api/Program.cs
+++ b/src/FastTechFoods.Api/Program.cs
@@ -1,0 +1,59 @@
+using FastTechFoods.Application.DTOs;
+using FastTechFoods.Application.Interfaces;
+using FastTechFoods.Infrastructure;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+builder.Services.AddFluentValidationAutoValidation();
+
+string connectionString = builder.Configuration.GetConnectionString("Default") ?? "Host=localhost;Database=fasttechfoods;Username=postgres;Password=postgres";
+builder.Services.AddInfrastructure(connectionString);
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.MapGet("/api/menu", async (IProductService service, CancellationToken ct) =>
+    Results.Ok(await service.GetAllAsync(ct)));
+
+app.MapGet("/api/menu/{id}", async (Guid id, IProductService service, CancellationToken ct) =>
+{
+    var product = await service.GetByIdAsync(id, ct);
+    return product is not null ? Results.Ok(product) : Results.NotFound();
+});
+
+app.MapPost("/api/menu", async (CreateProductRequest request, IProductService service, IValidator<CreateProductRequest> validator, CancellationToken ct) =>
+{
+    var validation = await validator.ValidateAsync(request, ct);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    var result = await service.CreateAsync(request, ct);
+    return Results.Created($"/api/menu/{result.Id}", result);
+});
+
+app.MapPut("/api/menu/{id}", async (Guid id, UpdateProductRequest request, IProductService service, IValidator<UpdateProductRequest> validator, CancellationToken ct) =>
+{
+    var validation = await validator.ValidateAsync(request, ct);
+    if (!validation.IsValid)
+        return Results.BadRequest(validation.Errors);
+
+    var updated = await service.UpdateAsync(id, request, ct);
+    return updated is not null ? Results.Ok(updated) : Results.NotFound();
+});
+
+app.MapDelete("/api/menu/{id}", async (Guid id, IProductService service, CancellationToken ct) =>
+{
+    var deleted = await service.DeleteAsync(id, ct);
+    return deleted ? Results.NoContent() : Results.NotFound();
+});
+
+app.Run();

--- a/src/FastTechFoods.Api/Properties/launchSettings.json
+++ b/src/FastTechFoods.Api/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:63382",
+      "sslPort": 44341
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5038",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7183;http://localhost:5038",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/FastTechFoods.Api/appsettings.Development.json
+++ b/src/FastTechFoods.Api/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/FastTechFoods.Api/appsettings.json
+++ b/src/FastTechFoods.Api/appsettings.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Database=fasttechfoods;Username=postgres;Password=postgres"
+  }
+}

--- a/src/FastTechFoods.Application/DTOs/CreateProductRequest.cs
+++ b/src/FastTechFoods.Application/DTOs/CreateProductRequest.cs
@@ -1,0 +1,10 @@
+namespace FastTechFoods.Application.DTOs;
+
+public class CreateProductRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public bool Availability { get; set; }
+    public string Type { get; set; } = string.Empty;
+}

--- a/src/FastTechFoods.Application/DTOs/ProductDto.cs
+++ b/src/FastTechFoods.Application/DTOs/ProductDto.cs
@@ -1,0 +1,10 @@
+namespace FastTechFoods.Application.DTOs;
+
+public record ProductDto(
+    Guid Id,
+    string Name,
+    string Description,
+    decimal Price,
+    bool Availability,
+    string Type,
+    DateTime CreatedDate);

--- a/src/FastTechFoods.Application/DTOs/UpdateProductRequest.cs
+++ b/src/FastTechFoods.Application/DTOs/UpdateProductRequest.cs
@@ -1,0 +1,10 @@
+namespace FastTechFoods.Application.DTOs;
+
+public class UpdateProductRequest
+{
+    public string Name { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public decimal Price { get; set; }
+    public bool Availability { get; set; }
+    public string Type { get; set; } = string.Empty;
+}

--- a/src/FastTechFoods.Application/FastTechFoods.Application.csproj
+++ b/src/FastTechFoods.Application/FastTechFoods.Application.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastTechFoods.Domain\FastTechFoods.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FastTechFoods.Application/Interfaces/IProductService.cs
+++ b/src/FastTechFoods.Application/Interfaces/IProductService.cs
@@ -1,0 +1,12 @@
+using FastTechFoods.Application.DTOs;
+
+namespace FastTechFoods.Application.Interfaces;
+
+public interface IProductService
+{
+    Task<IEnumerable<ProductDto>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<ProductDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ProductDto> CreateAsync(CreateProductRequest request, CancellationToken cancellationToken = default);
+    Task<ProductDto?> UpdateAsync(Guid id, UpdateProductRequest request, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/src/FastTechFoods.Application/Services/ProductService.cs
+++ b/src/FastTechFoods.Application/Services/ProductService.cs
@@ -1,0 +1,65 @@
+using FastTechFoods.Application.DTOs;
+using FastTechFoods.Application.Interfaces;
+using FastTechFoods.Domain.Entities;
+using FastTechFoods.Domain.Repositories;
+
+namespace FastTechFoods.Application.Services;
+
+public class ProductService : IProductService
+{
+    private readonly IProductRepository _repository;
+
+    public ProductService(IProductRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<ProductDto>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var products = await _repository.GetAllAsync(cancellationToken);
+        return products.Select(ToDto);
+    }
+
+    public async Task<ProductDto?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var product = await _repository.GetByIdAsync(id, cancellationToken);
+        return product is null ? null : ToDto(product);
+    }
+
+    public async Task<ProductDto> CreateAsync(CreateProductRequest request, CancellationToken cancellationToken = default)
+    {
+        var product = new Product(request.Name, request.Description, request.Price, request.Availability, request.Type);
+        await _repository.AddAsync(product, cancellationToken);
+        return ToDto(product);
+    }
+
+    public async Task<ProductDto?> UpdateAsync(Guid id, UpdateProductRequest request, CancellationToken cancellationToken = default)
+    {
+        var product = await _repository.GetByIdAsync(id, cancellationToken);
+        if (product is null)
+            return null;
+
+        product.Update(request.Name, request.Description, request.Price, request.Availability, request.Type);
+        await _repository.UpdateAsync(product, cancellationToken);
+        return ToDto(product);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var product = await _repository.GetByIdAsync(id, cancellationToken);
+        if (product is null)
+            return false;
+
+        await _repository.DeleteAsync(product, cancellationToken);
+        return true;
+    }
+
+    private static ProductDto ToDto(Product product) => new(
+        product.Id,
+        product.Name,
+        product.Description,
+        product.Price,
+        product.Availability,
+        product.Type,
+        product.CreatedDate);
+}

--- a/src/FastTechFoods.Application/Validators/CreateProductRequestValidator.cs
+++ b/src/FastTechFoods.Application/Validators/CreateProductRequestValidator.cs
@@ -1,0 +1,15 @@
+using FastTechFoods.Application.DTOs;
+using FluentValidation;
+
+namespace FastTechFoods.Application.Validators;
+
+public class CreateProductRequestValidator : AbstractValidator<CreateProductRequest>
+{
+    public CreateProductRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.Price).GreaterThan(0);
+        RuleFor(x => x.Type).NotEmpty().MaximumLength(100);
+    }
+}

--- a/src/FastTechFoods.Application/Validators/UpdateProductRequestValidator.cs
+++ b/src/FastTechFoods.Application/Validators/UpdateProductRequestValidator.cs
@@ -1,0 +1,15 @@
+using FastTechFoods.Application.DTOs;
+using FluentValidation;
+
+namespace FastTechFoods.Application.Validators;
+
+public class UpdateProductRequestValidator : AbstractValidator<UpdateProductRequest>
+{
+    public UpdateProductRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.Price).GreaterThan(0);
+        RuleFor(x => x.Type).NotEmpty().MaximumLength(100);
+    }
+}

--- a/src/FastTechFoods.Domain/Entities/Product.cs
+++ b/src/FastTechFoods.Domain/Entities/Product.cs
@@ -1,0 +1,39 @@
+namespace FastTechFoods.Domain.Entities;
+
+public class Product
+{
+    public Guid Id { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public string Description { get; private set; } = string.Empty;
+    public decimal Price { get; private set; }
+    public bool Availability { get; private set; }
+    public string Type { get; private set; } = string.Empty;
+    public DateTime CreatedDate { get; private set; }
+
+    protected Product() { }
+
+    public Product(string name, string description, decimal price, bool availability, string type)
+    {
+        Id = Guid.NewGuid();
+        Name = name;
+        Description = description;
+        Price = price;
+        Availability = availability;
+        Type = type;
+        CreatedDate = DateTime.UtcNow;
+    }
+
+    public void Update(string name, string description, decimal price, bool availability, string type)
+    {
+        Name = name;
+        Description = description;
+        Price = price;
+        Availability = availability;
+        Type = type;
+    }
+
+    public void SetAvailability(bool availability)
+    {
+        Availability = availability;
+    }
+}

--- a/src/FastTechFoods.Domain/FastTechFoods.Domain.csproj
+++ b/src/FastTechFoods.Domain/FastTechFoods.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FastTechFoods.Domain/Repositories/IProductRepository.cs
+++ b/src/FastTechFoods.Domain/Repositories/IProductRepository.cs
@@ -1,0 +1,12 @@
+using FastTechFoods.Domain.Entities;
+
+namespace FastTechFoods.Domain.Repositories;
+
+public interface IProductRepository
+{
+    Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Product>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task AddAsync(Product product, CancellationToken cancellationToken = default);
+    Task UpdateAsync(Product product, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Product product, CancellationToken cancellationToken = default);
+}

--- a/src/FastTechFoods.Infrastructure/Data/AppDbContext.cs
+++ b/src/FastTechFoods.Infrastructure/Data/AppDbContext.cs
@@ -1,0 +1,29 @@
+using FastTechFoods.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace FastTechFoods.Infrastructure.Data;
+
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<Product> Products => Set<Product>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.Entity<Product>(entity =>
+        {
+            entity.ToTable("Products");
+            entity.HasKey(p => p.Id);
+            entity.Property(p => p.Name).IsRequired().HasMaxLength(200);
+            entity.Property(p => p.Description).IsRequired().HasMaxLength(500);
+            entity.Property(p => p.Price).HasColumnType("decimal(10,2)");
+            entity.Property(p => p.Availability).IsRequired();
+            entity.Property(p => p.Type).IsRequired().HasMaxLength(100);
+            entity.Property(p => p.CreatedDate).IsRequired();
+        });
+    }
+}

--- a/src/FastTechFoods.Infrastructure/FastTechFoods.Infrastructure.csproj
+++ b/src/FastTechFoods.Infrastructure/FastTechFoods.Infrastructure.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastTechFoods.Domain\FastTechFoods.Domain.csproj" />
+    <ProjectReference Include="..\FastTechFoods.Application\FastTechFoods.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="12.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/FastTechFoods.Infrastructure/Repositories/ProductRepository.cs
+++ b/src/FastTechFoods.Infrastructure/Repositories/ProductRepository.cs
@@ -1,0 +1,48 @@
+using FastTechFoods.Domain.Entities;
+using FastTechFoods.Domain.Repositories;
+using FastTechFoods.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace FastTechFoods.Infrastructure.Repositories;
+
+public class ProductRepository : IProductRepository
+{
+    private readonly AppDbContext _context;
+
+    public ProductRepository(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Product?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _context.Products.FirstOrDefaultAsync(p => p.Id == id, cancellationToken);
+    }
+
+    public async Task<IEnumerable<Product>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Products
+            .AsNoTracking()
+            .Where(p => p.Availability)
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task AddAsync(Product product, CancellationToken cancellationToken = default)
+    {
+        await _context.Products.AddAsync(product, cancellationToken);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(Product product, CancellationToken cancellationToken = default)
+    {
+        _context.Products.Update(product);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Product product, CancellationToken cancellationToken = default)
+    {
+        _context.Products.Remove(product);
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/FastTechFoods.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/FastTechFoods.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,24 @@
+using FastTechFoods.Application.Interfaces;
+using FastTechFoods.Application.Validators;
+using FastTechFoods.Application.Services;
+using FastTechFoods.Domain.Repositories;
+using FastTechFoods.Infrastructure.Data;
+using FastTechFoods.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using FluentValidation;
+
+namespace FastTechFoods.Infrastructure;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddInfrastructure(this IServiceCollection services, string connectionString)
+    {
+        services.AddDbContext<AppDbContext>(options =>
+            options.UseNpgsql(connectionString));
+        services.AddScoped<IProductRepository, ProductRepository>();
+        services.AddScoped<IProductService, ProductService>();
+        services.AddValidatorsFromAssemblyContaining<CreateProductRequestValidator>();
+        return services;
+    }
+}


### PR DESCRIPTION
## Summary
- initialize solution with domain, application, infrastructure, and API projects
- define Product entity, repository and service
- implement EF Core context and repository for PostgreSQL
- expose minimal API endpoints with FluentValidation
- filter repository's GetAllAsync to return only available products

## Testing
- `dotnet build FastTechFoods.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6869a01d042883298c988e40b9f432a7