### PR TITLE
Add ProductType enum

### DIFF
--- a/FastTechFoods.sln
+++ b/FastTechFoods.sln
@@ -13,6 +13,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Infrastructur
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Api", "src\FastTechFoods.Api\FastTechFoods.Api.csproj", "{927CD36E-984D-4A4E-87EA-B77BF07BB54A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CA3C979D-324B-4293-BE42-CBF5A6323CF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Application.Tests", "tests\FastTechFoods.Application.Tests\FastTechFoods.Application.Tests.csproj", "{F8BFD1AA-1007-40CB-9260-F3CACA55850A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FastTechFoods.Domain.Tests", "tests\FastTechFoods.Domain.Tests\FastTechFoods.Domain.Tests.csproj", "{F069EF29-7288-42D4-B8CC-27B26D77F02D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -36,13 +42,23 @@ Global
 		{CF68CDE7-3D6E-4420-A349-EC344099A159}.Release|Any CPU.Build.0 = Release|Any CPU
 		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{35143948-E620-4558-B567-1F375A013EEC} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
-		{AAA3A1C6-8CEE-4856-BC8D-AA40B6310498} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
-		{CF68CDE7-3D6E-4420-A349-EC344099A159} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
-		{927CD36E-984D-4A4E-87EA-B77BF07BB54A} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
-	EndGlobalSection
+                {927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {927CD36E-984D-4A4E-87EA-B77BF07BB54A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F8BFD1AA-1007-40CB-9260-F3CACA55850A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F8BFD1AA-1007-40CB-9260-F3CACA55850A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F8BFD1AA-1007-40CB-9260-F3CACA55850A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F8BFD1AA-1007-40CB-9260-F3CACA55850A}.Release|Any CPU.Build.0 = Release|Any CPU
+                {F069EF29-7288-42D4-B8CC-27B26D77F02D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {F069EF29-7288-42D4-B8CC-27B26D77F02D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {F069EF29-7288-42D4-B8CC-27B26D77F02D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {F069EF29-7288-42D4-B8CC-27B26D77F02D}.Release|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
+        GlobalSection(NestedProjects) = preSolution
+                {35143948-E620-4558-B567-1F375A013EEC} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+                {AAA3A1C6-8CEE-4856-BC8D-AA40B6310498} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+                {CF68CDE7-3D6E-4420-A349-EC344099A159} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+                {927CD36E-984D-4A4E-87EA-B77BF07BB54A} = {5A0D4392-0E94-48F3-889D-8A344F2A074F}
+                {F8BFD1AA-1007-40CB-9260-F3CACA55850A} = {CA3C979D-324B-4293-BE42-CBF5A6323CF9}
+                {F069EF29-7288-42D4-B8CC-27B26D77F02D} = {CA3C979D-324B-4293-BE42-CBF5A6323CF9}
+        EndGlobalSection
 EndGlobal

--- a/src/FastTechFoods.Application/DTOs/CreateProductRequest.cs
+++ b/src/FastTechFoods.Application/DTOs/CreateProductRequest.cs
@@ -1,3 +1,5 @@
+using FastTechFoods.Domain.Entities;
+
 namespace FastTechFoods.Application.DTOs;
 
 public class CreateProductRequest
@@ -6,5 +8,5 @@ public class CreateProductRequest
     public string Description { get; set; } = string.Empty;
     public decimal Price { get; set; }
     public bool Availability { get; set; }
-    public string Type { get; set; } = string.Empty;
+    public ProductType Type { get; set; }
 }

--- a/src/FastTechFoods.Application/DTOs/ProductDto.cs
+++ b/src/FastTechFoods.Application/DTOs/ProductDto.cs
@@ -1,3 +1,5 @@
+using FastTechFoods.Domain.Entities;
+
 namespace FastTechFoods.Application.DTOs;
 
 public record ProductDto(
@@ -6,5 +8,5 @@ public record ProductDto(
     string Description,
     decimal Price,
     bool Availability,
-    string Type,
+    ProductType Type,
     DateTime CreatedDate);

--- a/src/FastTechFoods.Application/DTOs/UpdateProductRequest.cs
+++ b/src/FastTechFoods.Application/DTOs/UpdateProductRequest.cs
@@ -1,3 +1,5 @@
+using FastTechFoods.Domain.Entities;
+
 namespace FastTechFoods.Application.DTOs;
 
 public class UpdateProductRequest
@@ -6,5 +8,5 @@ public class UpdateProductRequest
     public string Description { get; set; } = string.Empty;
     public decimal Price { get; set; }
     public bool Availability { get; set; }
-    public string Type { get; set; } = string.Empty;
+    public ProductType Type { get; set; }
 }

--- a/src/FastTechFoods.Application/Validators/CreateProductRequestValidator.cs
+++ b/src/FastTechFoods.Application/Validators/CreateProductRequestValidator.cs
@@ -10,6 +10,6 @@ public class CreateProductRequestValidator : AbstractValidator<CreateProductRequ
         RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
         RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
         RuleFor(x => x.Price).GreaterThan(0);
-        RuleFor(x => x.Type).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Type).IsInEnum();
     }
 }

--- a/src/FastTechFoods.Application/Validators/UpdateProductRequestValidator.cs
+++ b/src/FastTechFoods.Application/Validators/UpdateProductRequestValidator.cs
@@ -10,6 +10,6 @@ public class UpdateProductRequestValidator : AbstractValidator<UpdateProductRequ
         RuleFor(x => x.Name).NotEmpty().MaximumLength(200);
         RuleFor(x => x.Description).NotEmpty().MaximumLength(500);
         RuleFor(x => x.Price).GreaterThan(0);
-        RuleFor(x => x.Type).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Type).IsInEnum();
     }
 }

--- a/src/FastTechFoods.Domain/Entities/Product.cs
+++ b/src/FastTechFoods.Domain/Entities/Product.cs
@@ -7,12 +7,12 @@ public class Product
     public string Description { get; private set; } = string.Empty;
     public decimal Price { get; private set; }
     public bool Availability { get; private set; }
-    public string Type { get; private set; } = string.Empty;
+    public ProductType Type { get; private set; }
     public DateTime CreatedDate { get; private set; }
 
     protected Product() { }
 
-    public Product(string name, string description, decimal price, bool availability, string type)
+    public Product(string name, string description, decimal price, bool availability, ProductType type)
     {
         Id = Guid.NewGuid();
         Name = name;
@@ -23,7 +23,7 @@ public class Product
         CreatedDate = DateTime.UtcNow;
     }
 
-    public void Update(string name, string description, decimal price, bool availability, string type)
+    public void Update(string name, string description, decimal price, bool availability, ProductType type)
     {
         Name = name;
         Description = description;

--- a/src/FastTechFoods.Domain/Entities/ProductType.cs
+++ b/src/FastTechFoods.Domain/Entities/ProductType.cs
@@ -1,0 +1,8 @@
+namespace FastTechFoods.Domain.Entities;
+
+public enum ProductType
+{
+    Snack,
+    Dessert,
+    Drink
+}

--- a/src/FastTechFoods.Infrastructure/Data/AppDbContext.cs
+++ b/src/FastTechFoods.Infrastructure/Data/AppDbContext.cs
@@ -22,7 +22,10 @@ public class AppDbContext : DbContext
             entity.Property(p => p.Description).IsRequired().HasMaxLength(500);
             entity.Property(p => p.Price).HasColumnType("decimal(10,2)");
             entity.Property(p => p.Availability).IsRequired();
-            entity.Property(p => p.Type).IsRequired().HasMaxLength(100);
+            entity.Property(p => p.Type)
+                .HasConversion<string>()
+                .IsRequired()
+                .HasMaxLength(100);
             entity.Property(p => p.CreatedDate).IsRequired();
         });
     }

--- a/tests/FastTechFoods.Application.Tests/FastTechFoods.Application.Tests.csproj
+++ b/tests/FastTechFoods.Application.Tests/FastTechFoods.Application.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FastTechFoods.Application\FastTechFoods.Application.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/FastTechFoods.Application.Tests/Services/ProductServiceTests.cs
+++ b/tests/FastTechFoods.Application.Tests/Services/ProductServiceTests.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FastTechFoods.Application.DTOs;
+using FastTechFoods.Application.Services;
+using FastTechFoods.Domain.Entities;
+using FastTechFoods.Domain.Repositories;
+using Moq;
+using Xunit;
+
+namespace FastTechFoods.Application.Tests.Services;
+
+public class ProductServiceTests
+{
+    private readonly Mock<IProductRepository> _repoMock = new();
+    private readonly ProductService _service;
+
+    public ProductServiceTests()
+    {
+        _service = new ProductService(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task GetAllAsync_ReturnsMappedDtos()
+    {
+        // Arrange
+        var products = new List<Product>
+        {
+            new("Burger","Tasty",10m,true,ProductType.Snack),
+            new("Fries","Crispy",5m,true,ProductType.Dessert)
+        };
+        _repoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(products);
+
+        // Act
+        var result = await _service.GetAllAsync();
+
+        // Assert
+        Assert.Equal(products.Count, result.Count());
+        Assert.Contains(result, p => p.Name == "Burger" && p.Description == "Tasty");
+        Assert.Contains(result, p => p.Name == "Fries" && p.Description == "Crispy");
+    }
+
+    [Fact]
+    public async Task GetByIdAsync_WhenNotFound_ReturnsNull()
+    {
+        // Arrange
+        _repoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Product?)null);
+
+        // Act
+        var result = await _service.GetByIdAsync(Guid.NewGuid());
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CreateAsync_CallsRepositoryAndReturnsDto()
+    {
+        // Arrange
+        Product? captured = null;
+        _repoMock.Setup(r => r.AddAsync(It.IsAny<Product>(), It.IsAny<CancellationToken>()))
+            .Callback<Product, CancellationToken>((p, _) => captured = p)
+            .Returns(Task.CompletedTask);
+
+        var request = new CreateProductRequest
+        {
+            Name = "Soda",
+            Description = "Cola",
+            Price = 3.5m,
+            Availability = true,
+            Type = ProductType.Drink
+        };
+
+        // Act
+        var result = await _service.CreateAsync(request);
+
+        // Assert
+        _repoMock.Verify(r => r.AddAsync(It.IsAny<Product>(), It.IsAny<CancellationToken>()), Times.Once);
+        Assert.NotNull(captured);
+        Assert.Equal(request.Name, captured!.Name);
+        Assert.Equal(request.Description, captured.Description);
+        Assert.Equal(request.Price, captured.Price);
+        Assert.Equal(request.Type, captured.Type);
+        Assert.Equal(result.Name, request.Name);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WhenProductNotFound_ReturnsNull()
+    {
+        // Arrange
+        _repoMock.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Product?)null);
+
+        var request = new UpdateProductRequest
+        {
+            Name = "Updated",
+            Description = "Updated desc",
+            Price = 2,
+            Availability = true,
+            Type = ProductType.Snack
+        };
+
+        // Act
+        var result = await _service.UpdateAsync(Guid.NewGuid(), request);
+
+        // Assert
+        Assert.Null(result);
+        _repoMock.Verify(r => r.UpdateAsync(It.IsAny<Product>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WhenProductExists_ReturnsTrue()
+    {
+        // Arrange
+        var product = new Product("Burger","Tasty",10m,true,ProductType.Snack);
+        _repoMock.Setup(r => r.GetByIdAsync(product.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+        _repoMock.Setup(r => r.DeleteAsync(product, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _service.DeleteAsync(product.Id);
+
+        // Assert
+        Assert.True(result);
+        _repoMock.Verify(r => r.DeleteAsync(product, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/FastTechFoods.Domain.Tests/Entities/ProductTests.cs
+++ b/tests/FastTechFoods.Domain.Tests/Entities/ProductTests.cs
@@ -1,0 +1,48 @@
+using System;
+using FastTechFoods.Domain.Entities;
+using Xunit;
+
+namespace FastTechFoods.Domain.Tests.Entities;
+
+public class ProductTests
+{
+    [Fact]
+    public void Constructor_SetsProperties()
+    {
+        var before = DateTime.UtcNow;
+
+        var product = new Product("Burger", "Tasty", 10m, true, ProductType.Snack);
+
+        Assert.Equal("Burger", product.Name);
+        Assert.Equal("Tasty", product.Description);
+        Assert.Equal(10m, product.Price);
+        Assert.True(product.Availability);
+        Assert.Equal(ProductType.Snack, product.Type);
+        Assert.NotEqual(Guid.Empty, product.Id);
+        Assert.InRange(product.CreatedDate, before, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public void Update_ChangesProperties()
+    {
+        var product = new Product("Burger", "Tasty", 10m, true, ProductType.Snack);
+
+        product.Update("Fries", "Crispy", 5m, false, ProductType.Dessert);
+
+        Assert.Equal("Fries", product.Name);
+        Assert.Equal("Crispy", product.Description);
+        Assert.Equal(5m, product.Price);
+        Assert.False(product.Availability);
+        Assert.Equal(ProductType.Dessert, product.Type);
+    }
+
+    [Fact]
+    public void SetAvailability_ChangesAvailabilityOnly()
+    {
+        var product = new Product("Burger", "Tasty", 10m, true, ProductType.Snack);
+
+        product.SetAvailability(false);
+
+        Assert.False(product.Availability);
+    }
+}

--- a/tests/FastTechFoods.Domain.Tests/FastTechFoods.Domain.Tests.csproj
+++ b/tests/FastTechFoods.Domain.Tests/FastTechFoods.Domain.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\FastTechFoods.Domain\FastTechFoods.Domain.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- define `ProductType` enum
- refactor Product entity and DTOs to use enum instead of string
- map enum to string in EF configuration
- update validators, services and tests

## Testing
- `dotnet build FastTechFoods.sln`
- `dotnet test FastTechFoods.sln` *(fails: missing Newtonsoft.Json dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6869a4caf5548329b8158f89239b7376