### PR TITLE
Fix API publish path

### DIFF
--- a/.github/workflows/main_fasttechfoodscatalog.yml
+++ b/.github/workflows/main_fasttechfoodscatalog.yml
@@ -30,7 +30,7 @@ jobs:
         run: dotnet test --no-build --configuration Release
 
       - name: dotnet publish
-        run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp
+        run: dotnet publish src/FastTechFoods.Api/FastTechFoods.Api.csproj -c Release -o ${{env.DOTNET_ROOT}}/myapp
 
       - name: Upload artifact for deployment job
         uses: actions/upload-artifact@v4
@@ -64,5 +64,5 @@ jobs:
         with:
           app-name: 'FastTechFoodsCatalog'
           slot-name: 'Production'
-          package: .
+          package: ${{env.DOTNET_ROOT}}/myapp
           


### PR DESCRIPTION
## Summary
- publish the API project when building
- deploy from the published output folder

## Testing
- `dotnet test -v diag` *(fails: current .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6869c592e9188329a2c4b647e7c988f8